### PR TITLE
ci: create a workflow for continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI Autotools/C
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: configure
+      run: ./bootstrap && ./configure
+    - name: make
+      run: make
+    - name: make check
+      run: make check
+    - name: make distcheck
+      run: make distcheck


### PR DESCRIPTION
Start a baseline for continuous integration to run the
checks as part of the auto tools invocation. This is
a basic
* autoreconf
* configure
* make
* make check

Signed-off-by: Charles Hardin <ckhardin@gmail.com>